### PR TITLE
Set FFMpeg User-Agent

### DIFF
--- a/games.py
+++ b/games.py
@@ -78,7 +78,7 @@ def getGameUrl(video_id, video_type, video_ishomefeed):
     else:
         # Archive and condensed flow: We now work with HLS. 
         # The cookies are already in the URL and the server will supply them to ffmpeg later.
-        selected_video_url = getGameUrlWithBitrate(url, video_type)
+        selected_video_url = "%s|User-Agent=iTunes-AppleTV/4.1" % getGameUrlWithBitrate(url, video_type)
         
         
     if selected_video_url:


### PR DESCRIPTION
Fixes #46 inline with @kaileu suggestion
Sets the User-Agent used by FFMpeg to the AppleTV useragent string, as the default Kodi useragent string appears to blocked.